### PR TITLE
Fix session generation in examples

### DIFF
--- a/examples/gtt_order.py
+++ b/examples/gtt_order.py
@@ -11,7 +11,8 @@ kite = KiteConnect(api_key="your_api_key")
 # Once you have the request_token, obtain the access_token
 # as follows.
 
-data = kite.generate_session("request_token_here", secret="your_secret")
+# Generate a new session using the ``api_secret`` parameter
+data = kite.generate_session("request_token_here", api_secret="your_secret")
 kite.set_access_token(data["access_token"])
 
 # Place single-leg gtt order - https://kite.trade/docs/connect/v3/gtt/#single

--- a/examples/order_margins.py
+++ b/examples/order_margins.py
@@ -11,7 +11,8 @@ kite = KiteConnect(api_key="your_api_key")
 # Once you have the request_token, obtain the access_token
 # as follows.
 
-data = kite.generate_session("request_token_here", secret="your_secret")
+# Generate a new session using the ``api_secret`` parameter
+data = kite.generate_session("request_token_here", api_secret="your_secret")
 kite.set_access_token(data["access_token"])
 
 # Fetch margin detail for order/orders

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -11,7 +11,8 @@ kite = KiteConnect(api_key="your_api_key")
 # Once you have the request_token, obtain the access_token
 # as follows.
 
-data = kite.generate_session("request_token_here", secret="your_secret")
+# Generate a new session using the ``api_secret`` parameter
+data = kite.generate_session("request_token_here", api_secret="your_secret")
 kite.set_access_token(data["access_token"])
 
 # Place an order


### PR DESCRIPTION
## Summary
- update example scripts to use `api_secret` parameter when generating a session
- document new parameter usage for `generate_session`

## Testing
- `python examples/simple.py` *(fails: Token is invalid or has expired)*
- `python examples/gtt_order.py` *(fails: Token is invalid or has expired)*
- `python examples/order_margins.py` *(fails: Token is invalid or has expired)*
- `pytest -q` *(fails: FileNotFoundError for mock response files)*

------
https://chatgpt.com/codex/tasks/task_e_68642dfb5e888321b307d0e33e9b7d91