### PR TITLE
Fix SSL warning toggle

### DIFF
--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -213,8 +213,9 @@ class KiteConnect(object):
             reqadapter = requests.adapters.HTTPAdapter(**pool)
             self.reqsession.mount("https://", reqadapter)
 
-        # disable requests SSL warning
-        requests.packages.urllib3.disable_warnings()
+        # disable requests SSL warning when SSL verification is turned off
+        if self.disable_ssl:
+            requests.packages.urllib3.disable_warnings()
 
     def set_session_expiry_hook(self, method):
         """

--- a/tests/unit/test_kite_object.py
+++ b/tests/unit/test_kite_object.py
@@ -81,3 +81,15 @@ class TestKiteConnectObject:
     def test_invalidate_token(self, kiteconnect):
         resp = kiteconnect.invalidate_access_token(access_token="<ACCESS-TOKEN>")
         assert resp["message"] == "token invalidated"
+
+    def test_disable_warnings_called_when_ssl_disabled(self):
+        """Ensure urllib3 warnings are disabled when disable_ssl is True."""
+        with patch("requests.packages.urllib3.disable_warnings") as dw:
+            KiteConnect(api_key="<API-KEY>", disable_ssl=True)
+            dw.assert_called_once()
+
+    def test_disable_warnings_not_called_by_default(self):
+        """Ensure urllib3 warnings remain when disable_ssl is False."""
+        with patch("requests.packages.urllib3.disable_warnings") as dw:
+            KiteConnect(api_key="<API-KEY>")
+            dw.assert_not_called()


### PR DESCRIPTION
## Summary
- control urllib3 warnings based on `disable_ssl`
- test that SSL warnings only disabled when desired

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f6338e58832186c94b53e505ce06