### PR TITLE
Fix typo in comment

### DIFF
--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -53,7 +53,7 @@ class KiteConnect(object):
     ORDER_TYPE_SLM = "SL-M"
     ORDER_TYPE_SL = "SL"
 
-    # Varities
+    # Varieties
     VARIETY_REGULAR = "regular"
     VARIETY_CO = "co"
     VARIETY_AMO = "amo"


### PR DESCRIPTION
## Summary
- correct `Varities` typo in constants comment

## Testing
- `pytest -q` *(fails: FileNotFoundError in tests/mock_responses)*

------
https://chatgpt.com/codex/tasks/task_e_6864f639693483218f6e79785f552647