### PR TITLE
Check SSL flag before silencing urllib3 warnings

### DIFF
--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -216,6 +216,11 @@ class KiteConnect(object):
         # disable requests SSL warning when SSL verification is turned off
         if self.disable_ssl:
             requests.packages.urllib3.disable_warnings()
+        else:
+            warnings.filterwarnings(
+                "default",
+                category=requests.packages.urllib3.exceptions.HTTPWarning
+            )
 
     def set_session_expiry_hook(self, method):
         """


### PR DESCRIPTION
## Summary
- toggle urllib3 HTTP warnings based on `disable_ssl`
- test the new behaviour around warning filters

## Testing
- `pytest tests/unit/test_kite_object.py -q`
- `pytest -q` *(fails: FileNotFoundError for missing mock response files)*

------
https://chatgpt.com/codex/tasks/task_e_6864fe2fbf848321b3b63be1ab663e2e