### PR TITLE
Fix SSL warning handling

### DIFF
--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -213,8 +213,8 @@ class KiteConnect(object):
             reqadapter = requests.adapters.HTTPAdapter(**pool)
             self.reqsession.mount("https://", reqadapter)
 
-        # disable requests SSL warning when SSL verification is turned off
-        if self.disable_ssl:
+        # Disable requests SSL warnings only when verification is turned off
+        if disable_ssl:
             requests.packages.urllib3.disable_warnings()
         else:
             warnings.filterwarnings(


### PR DESCRIPTION
## Summary
- only call `requests.packages.urllib3.disable_warnings()` when `disable_ssl` is set

## Testing
- `pip install -r dev_requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650079051c83219287644ef20829cd