### PR TITLE
Fix trigger type validation in GTT placement

### DIFF
--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -735,7 +735,14 @@ class KiteConnect(object):
             - `price` The min or max price to execute the order at (for LIMIT orders)
         """
         # Validations.
-        assert trigger_type in [self.GTT_TYPE_OCO, self.GTT_TYPE_SINGLE]
+        if trigger_type not in [self.GTT_TYPE_OCO, self.GTT_TYPE_SINGLE]:
+            raise ex.InputException(
+                "invalid `trigger_type` %s. Supported values are `%s` or `%s`" % (
+                    trigger_type,
+                    self.GTT_TYPE_SINGLE,
+                    self.GTT_TYPE_OCO,
+                )
+            )
         condition, gtt_orders = self._get_gtt_payload(trigger_type, tradingsymbol, exchange, trigger_values, last_price, orders)
 
         return self._post("gtt.place", params={

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -316,6 +316,26 @@ def test_place_gtt(kiteconnect):
 
 
 @responses.activate
+def test_place_gtt_invalid_trigger_type(kiteconnect):
+    """Ensure place_gtt raises InputException for invalid trigger type."""
+    with pytest.raises(ex.InputException):
+        kiteconnect.place_gtt(
+            trigger_type="invalid",
+            tradingsymbol="INFY",
+            exchange="NSE",
+            trigger_values=[1],
+            last_price=800,
+            orders=[{
+                "transaction_type": kiteconnect.TRANSACTION_TYPE_BUY,
+                "quantity": 1,
+                "order_type": kiteconnect.ORDER_TYPE_LIMIT,
+                "product": kiteconnect.PRODUCT_CNC,
+                "price": 1,
+            }]
+        )
+
+
+@responses.activate
 def test_modify_gtt(kiteconnect):
     """Test modify gtt order."""
     responses.add(


### PR DESCRIPTION
## Summary
- validate `trigger_type` in `place_gtt`
- raise `InputException` when invalid value is passed
- add regression test for invalid trigger type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865007f19a4832198d7cf1d6be217a6