### PR TITLE
Add close() to KiteConnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ kite.cancel_mf_order(order_id="order_id")
 
 # Get mutual fund instruments
 kite.mf_instruments()
+
+# Close the session when done
+kite.close()
+
+# Or use as a context manager
+with KiteConnect(api_key="your_api_key") as ck:
+    ck.instruments()
 ```
 
 Refer to the [Python client documentation](https://kite.trade/docs/pykiteconnect/v4) for the complete list of supported methods.

--- a/kiteconnect/connect.py
+++ b/kiteconnect/connect.py
@@ -222,6 +222,22 @@ class KiteConnect(object):
                 category=requests.packages.urllib3.exceptions.HTTPWarning
             )
 
+    def close(self):
+        """Close the underlying HTTP session."""
+        if getattr(self, "reqsession", None) is not None:
+            self.reqsession.close()
+
+    # ----------------------------------------------------------------
+    # Context manager support
+    # ----------------------------------------------------------------
+    def __enter__(self):
+        """Return self when entering context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Close the HTTP session on exiting context manager."""
+        self.close()
+
     def set_session_expiry_hook(self, method):
         """
         Set a callback hook for session (`TokenError` -- timeout, expiry etc.) errors.

--- a/tests/unit/test_kite_object.py
+++ b/tests/unit/test_kite_object.py
@@ -114,3 +114,17 @@ class TestKiteConnectObject:
                 f[0] == "ignore" and f[2] == requests.packages.urllib3.exceptions.HTTPWarning
                 for f in warnings.filters
             )
+
+    def test_close_closes_session(self, kiteconnect):
+        """Calling close() should close the underlying requests session."""
+        with patch.object(kiteconnect.reqsession, "close") as c:
+            kiteconnect.close()
+            c.assert_called_once()
+
+    def test_context_manager_closes_session(self):
+        """KiteConnect should support usage as a context manager."""
+        kite = KiteConnect(api_key="<API-KEY>")
+        with patch.object(kite.reqsession, "close") as c:
+            with kite as k:
+                assert k is kite
+            c.assert_called_once()


### PR DESCRIPTION
## Summary
- add `close()` and context manager support for `KiteConnect`
- document closing behaviour in `README`
- unit tests for `close()` and context manager

## Testing
- `pip install -q -r dev_requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865008416488321a00a67b4b0177fde