### PR TITLE
Add TradingView webhook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,45 @@ pip install pdoc
 pdoc --html --html-dir docs kiteconnect
 ```
 
+## TradingView integration
+
+`examples/tradingview_webhook.py` demonstrates a tiny Flask server that can
+receive alerts from TradingView and place orders via `KiteConnect`.
+
+TradingView alerts should POST a JSON payload to `/webhook` with the following
+structure:
+
+```json
+{
+  "api_key": "your_api_key",
+  "access_token": "your_access_token",
+  "orders": [
+    {
+      "exchange": "NSE",
+      "tradingsymbol": "SBIN",
+      "transaction_type": "BUY",
+      "quantity": 1,
+      "order_type": "MARKET",
+      "product": "CNC",
+      "variety": "regular"
+    }
+  ]
+}
+```
+
+The values inside each order map directly to the parameters accepted by
+`KiteConnect.place_order`. Multiple orders can be sent in the `orders` list to
+execute multi-leg strategies.
+
+Run the example with:
+
+```sh
+python examples/tradingview_webhook.py
+```
+
+Then configure your TradingView alert to POST the above JSON to the running
+server.
+
 ## Changelog
 
 [Check release notes](https://github.com/zerodha/pykiteconnect/releases)

--- a/examples/tradingview_webhook.py
+++ b/examples/tradingview_webhook.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+"""Simple webhook server to place orders from TradingView alerts.
+
+Run this example after replacing the API credentials and access token.
+TradingView alerts should POST JSON to ``/webhook`` in the format::
+
+    {
+        "api_key": "your_api_key",
+        "access_token": "your_access_token",
+        "orders": [
+            {
+                "exchange": "NSE",
+                "tradingsymbol": "SBIN",
+                "transaction_type": "BUY",
+                "quantity": 1,
+                "order_type": "MARKET",
+                "product": "CNC",
+                "variety": "regular"
+            }
+        ]
+    }
+
+Multiple orders can be passed in the ``orders`` list. Each object is mapped
+as-is to :py:meth:`KiteConnect.place_order` keyword arguments.
+"""
+
+import logging
+from flask import Flask, request, jsonify
+from kiteconnect import KiteConnect
+
+logging.basicConfig(level=logging.DEBUG)
+
+kite = KiteConnect(api_key="your_api_key")
+kite.set_access_token("your_access_token")
+
+app = Flask(__name__)
+
+
+@app.route("/webhook", methods=["POST"])
+def tradingview_webhook():
+    """Receive TradingView webhook and place orders."""
+    payload = request.get_json(force=True) or {}
+    orders = payload.get("orders") or []
+    if not isinstance(orders, list):
+        orders = [orders]
+
+    order_ids = []
+    for order in orders:
+        params = order.copy()
+        # Default to regular order if variety is not specified
+        params.setdefault("variety", kite.VARIETY_REGULAR)
+        order_id = kite.place_order(**params)
+        order_ids.append(order_id)
+
+    return jsonify({"order_ids": order_ids})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)


### PR DESCRIPTION
## Summary
- add TradingView webhook example using Flask
- document TradingView alert payload and usage in README

## Testing
- `pip install responses mock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865053d0d8c83219439b7a3f71882a8