### PR TITLE
Add env-based TradingView webhook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,42 +222,45 @@ pdoc --html --html-dir docs kiteconnect
 
 ## TradingView integration
 
-`examples/tradingview_webhook.py` demonstrates a tiny Flask server that can
-receive alerts from TradingView and place orders via `KiteConnect`.
+`examples/tradingview_webhook.py` exposes a small Flask server that accepts
+TradingView webhooks and forwards them to `KiteConnect`. Before running it,
+export the required credentials:
 
-TradingView alerts should POST a JSON payload to `/webhook` with the following
-structure:
+```sh
+export KITE_API_KEY="your_api_key"
+export KITE_API_SECRET="your_api_secret"
+export ACCESS_TOKEN="your_access_token"
+python examples/tradingview_webhook.py
+```
+
+TradingView should POST JSON to `/webhook` using the following structure:
 
 ```json
 {
-  "api_key": "your_api_key",
-  "access_token": "your_access_token",
   "orders": [
     {
-      "exchange": "NSE",
-      "tradingsymbol": "SBIN",
+      "symbol": "NIFTY24AUG17450CE",
       "transaction_type": "BUY",
-      "quantity": 1,
+      "quantity": 75,
+      "exchange": "NFO",
       "order_type": "MARKET",
-      "product": "CNC",
-      "variety": "regular"
+      "product": "MIS"
+    },
+    {
+      "symbol": "NIFTY24AUG17650CE",
+      "transaction_type": "SELL",
+      "quantity": 75,
+      "exchange": "NFO",
+      "order_type": "MARKET",
+      "product": "MIS"
     }
   ]
 }
 ```
 
-The values inside each order map directly to the parameters accepted by
-`KiteConnect.place_order`. Multiple orders can be sent in the `orders` list to
-execute multi-leg strategies.
-
-Run the example with:
-
-```sh
-python examples/tradingview_webhook.py
-```
-
-Then configure your TradingView alert to POST the above JSON to the running
-server.
+Each item in `orders` maps to the arguments of
+`KiteConnect.place_order`. Multiple items may be provided to execute
+multi-leg option strategies.
 
 ## Changelog
 

--- a/examples/tradingview_webhook.py
+++ b/examples/tradingview_webhook.py
@@ -1,37 +1,54 @@
 # coding: utf-8
 """Simple webhook server to place orders from TradingView alerts.
 
-Run this example after replacing the API credentials and access token.
-TradingView alerts should POST JSON to ``/webhook`` in the format::
+The script expects the following environment variables to be set:
+
+``KITE_API_KEY``      – Your Kite Connect API key.
+``KITE_API_SECRET``   – API secret used when generating the access token.
+``ACCESS_TOKEN``      – A valid access token for the above key.
+
+TradingView alerts should POST JSON data to ``/webhook`` in the following
+format::
 
     {
-        "api_key": "your_api_key",
-        "access_token": "your_access_token",
         "orders": [
             {
-                "exchange": "NSE",
-                "tradingsymbol": "SBIN",
+                "symbol": "NIFTY24AUG17450CE",
                 "transaction_type": "BUY",
-                "quantity": 1,
+                "quantity": 75,
+                "exchange": "NFO",
                 "order_type": "MARKET",
-                "product": "CNC",
-                "variety": "regular"
+                "product": "MIS"
+            },
+            {
+                "symbol": "NIFTY24AUG17650CE",
+                "transaction_type": "SELL",
+                "quantity": 75,
+                "exchange": "NFO",
+                "order_type": "MARKET",
+                "product": "MIS"
             }
         ]
     }
 
-Multiple orders can be passed in the ``orders`` list. Each object is mapped
-as-is to :py:meth:`KiteConnect.place_order` keyword arguments.
+Every entry in ``orders`` maps directly to the parameters accepted by
+:py:meth:`KiteConnect.place_order`. Multiple entries can be sent to execute
+multi-leg option strategies.
 """
 
 import logging
+import os
 from flask import Flask, request, jsonify
 from kiteconnect import KiteConnect
 
 logging.basicConfig(level=logging.DEBUG)
 
-kite = KiteConnect(api_key="your_api_key")
-kite.set_access_token("your_access_token")
+kite_api_key = os.environ["KITE_API_KEY"]
+kite_api_secret = os.environ.get("KITE_API_SECRET")
+access_token = os.environ["ACCESS_TOKEN"]
+
+kite = KiteConnect(api_key=kite_api_key)
+kite.set_access_token(access_token)
 
 app = Flask(__name__)
 
@@ -46,9 +63,19 @@ def tradingview_webhook():
 
     order_ids = []
     for order in orders:
-        params = order.copy()
-        # Default to regular order if variety is not specified
-        params.setdefault("variety", kite.VARIETY_REGULAR)
+        params = {
+            "tradingsymbol": order.get("symbol") or order.get("tradingsymbol"),
+            "exchange": order.get("exchange", kite.EXCHANGE_NSE),
+            "transaction_type": order.get("transaction_type"),
+            "quantity": order.get("quantity", 1),
+            "order_type": order.get("order_type", kite.ORDER_TYPE_MARKET),
+            "product": order.get("product", kite.PRODUCT_CNC),
+            "variety": order.get("variety", kite.VARIETY_REGULAR),
+        }
+
+        # Filter out unset keys
+        params = {k: v for k, v in params.items() if v is not None}
+
         order_id = kite.place_order(**params)
         order_ids.append(order_id)
 


### PR DESCRIPTION
## Summary
- improve TradingView webhook example
- document env vars and JSON payload in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865090e82c483218bbfb88356e467df