### PR TITLE
Add webhook tests

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,4 @@ flake8>=3.8.4, <= 4.0.1
 mock>=3.0.5
 urllib3<2.0
 autobahn[twisted]==19.11.2
+flask>=3.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-testpaths = tests/unit
+testpaths =
+    tests/unit
+    tests/test_webhook.py
 addopts =
     -r fEsxXw
     -vvv

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,78 @@
+import pytest
+from unittest.mock import patch, call
+
+from examples import tradingview_webhook
+from kiteconnect.connect import KiteConnect
+
+
+@pytest.fixture
+def client():
+    """Flask test client for the webhook example."""
+    tradingview_webhook.app.config['TESTING'] = True
+    with tradingview_webhook.app.test_client() as client:
+        yield client
+
+
+def test_single_order_defaults_variety(client):
+    order = {
+        "exchange": "NSE",
+        "tradingsymbol": "SBIN",
+        "transaction_type": "BUY",
+        "quantity": 1,
+        "order_type": "MARKET",
+        "product": "CNC"
+    }
+    expected = order.copy()
+    expected["variety"] = tradingview_webhook.kite.VARIETY_REGULAR
+
+    with patch.object(KiteConnect, "place_order", return_value="101") as po:
+        resp = client.post("/webhook", json={"orders": order})
+        assert resp.status_code == 200
+        assert resp.get_json() == {"order_ids": ["101"]}
+        po.assert_called_once_with(**expected)
+
+
+def test_multiple_orders(client):
+    orders = [
+        {
+            "exchange": "NSE",
+            "tradingsymbol": "SBIN",
+            "transaction_type": "BUY",
+            "quantity": 1,
+            "order_type": "MARKET",
+            "product": "CNC",
+            "variety": "amo"
+        },
+        {
+            "exchange": "NSE",
+            "tradingsymbol": "INFY",
+            "transaction_type": "SELL",
+            "quantity": 2,
+            "order_type": "LIMIT",
+            "product": "CNC",
+            "variety": "regular"
+        }
+    ]
+    with patch.object(KiteConnect, "place_order", side_effect=["111", "222"]) as po:
+        resp = client.post("/webhook", json={"orders": orders})
+        assert resp.status_code == 200
+        assert resp.get_json() == {"order_ids": ["111", "222"]}
+        assert po.call_args_list == [
+            call(**orders[0]),
+            call(**orders[1])
+        ]
+
+
+def test_no_orders(client):
+    with patch.object(KiteConnect, "place_order") as po:
+        resp = client.post("/webhook", json={})
+        assert resp.status_code == 200
+        assert resp.get_json() == {"order_ids": []}
+        po.assert_not_called()
+
+
+def test_invalid_json(client):
+    with patch.object(KiteConnect, "place_order") as po:
+        resp = client.post("/webhook", data="{invalid", content_type="application/json")
+        assert resp.status_code == 400
+        po.assert_not_called()


### PR DESCRIPTION
## Summary
- add TradingView webhook test module
- include webhook tests in pytest config
- require Flask for testing

## Testing
- `pip install -r dev_requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865091731ec8321930847a85c2f7ad1