### PR TITLE
Add exit order handling to webhook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ TradingView should POST JSON to `/webhook` using the following structure:
 Each item in `orders` maps to the arguments of
 `KiteConnect.place_order`. Multiple items may be provided to execute
 multi-leg option strategies.
+Exit orders can be submitted via the `exit_orders` key which maps to the
+arguments of `KiteConnect.exit_order`.
 
 ## Changelog
 


### PR DESCRIPTION
## Summary
- extend `examples/tradingview_webhook.py` with exit order support
- document new `exit_orders` payload in README
- test exit order workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650a8b08f08321a1c00c39286ca37e