### PR TITLE
Fix tests by patching env vars

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,5 +1,13 @@
+import os
 import pytest
 from unittest.mock import patch, call
+
+# Ensure required environment variables are available before importing
+# the webhook example. These defaults let the import succeed without
+# external setup.
+os.environ.setdefault("KITE_API_KEY", "test_key")
+os.environ.setdefault("KITE_API_SECRET", "test_secret")
+os.environ.setdefault("ACCESS_TOKEN", "test_token")
 
 from examples import tradingview_webhook
 from kiteconnect.connect import KiteConnect


### PR DESCRIPTION
## Summary
- patch env vars at the start of `tests/test_webhook.py` so `examples.tradingview_webhook` can import without external setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686516ac6df48321b085369e9de7a592